### PR TITLE
Bump version, copyright year

### DIFF
--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -13,7 +13,7 @@ using System.Runtime.Versioning;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Paul Harrington")]
 [assembly: AssemblyProduct("Visual Studio Component Diagnostics")]
-[assembly: AssemblyCopyright("© 2018 Paul Harrington")]
+[assembly: AssemblyCopyright("© 2020 Paul Harrington")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]   
 [assembly: ComVisible(false)]     
@@ -30,8 +30,8 @@ using System.Runtime.Versioning;
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("1.20.0819.0")]
-[assembly: AssemblyFileVersion("1.20.0819.0")]
+[assembly: AssemblyVersion("1.20.1010.0")]
+[assembly: AssemblyFileVersion("1.20.1010.0")]
 
 // Declare the component guarantees. This is an assembly with internal API, that is not intended for public use.
 [assembly: ComponentGuarantees(ComponentGuaranteesOptions.None)]

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Paul Harrington.  All Rights Reserved.  Licensed under the MIT License.  See LICENSE in the project root for license information. -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="7f3371e3-c5e2-4323-bf6b-43b899ef434b" Version="1.20.0819.0" Language="en-US" Publisher="Paul Harrington" />
+        <Identity Id="7f3371e3-c5e2-4323-bf6b-43b899ef434b" Version="1.20.1010.0" Language="en-US" Publisher="Paul Harrington" />
         <DisplayName>Component Diagnostics</DisplayName>
         <Description xml:space="preserve">Advanced real-time diagnostics from various sub-systems within Visual Studio. Access the toolwindow from the Help menu.</Description>
         <MoreInfo>https://marketplace.visualstudio.com/items?itemName=PaulHarrington.ComponentDiagnostics</MoreInfo>
@@ -12,8 +13,7 @@
         <Tags>Diagnostics</Tags>
     </Metadata>
     <Installation InstalledByMsi="false">
-        <InstallationTarget Id="Microsoft.VisualStudio.IntegratedShell" Version="[11.0,15.0)" />
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0,17.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Bump assembly and VSIX version
Drop support for older VS versions. Support only VS 2019